### PR TITLE
Define payment request v1 contract

### DIFF
--- a/docs/payment-request.v1.md
+++ b/docs/payment-request.v1.md
@@ -1,0 +1,165 @@
+# payment-request.v1
+
+`payment-request.v1` is the canonical NFC payment request contract for Ding
+mobile and server flows. Producers must emit this exact shape, and consumers
+must reject invalid payloads with deterministic error codes.
+
+## Required Fields
+
+| Field       | Type   | Rule                                                                                                  |
+| ----------- | ------ | ----------------------------------------------------------------------------------------------------- |
+| `type`      | string | Must be `payment-request`.                                                                            |
+| `version`   | number | Must be `1`.                                                                                          |
+| `recipient` | string | Stellar public key in `G...` StrKey form: `^G[A-Z2-7]{55}$`.                                          |
+| `asset`     | string | MVP supports only `XLM` and `USDC`.                                                                   |
+| `amount`    | string | Positive decimal string with at most 7 decimal places.                                                |
+| `timestamp` | string | ISO 8601 UTC date-time within 5 minutes of server time.                                               |
+| `expiresAt` | string | ISO 8601 UTC date-time after `timestamp`, in the future, and no more than 24 hours after `timestamp`. |
+
+## Optional Fields
+
+| Field       | Type   | Rule                                                        |
+| ----------- | ------ | ----------------------------------------------------------- |
+| `memo`      | string | Optional user-facing memo, up to 280 characters.            |
+| `requestId` | string | Optional idempotency or trace identifier, 1-128 characters. |
+| `metadata`  | object | Optional JSON object for non-critical integration context.  |
+
+Unknown fields are rejected. Amounts are strings so NFC producers do not lose
+precision through JSON number parsing.
+
+## Valid Payload
+
+```json
+{
+  "type": "payment-request",
+  "version": 1,
+  "recipient": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "asset": "XLM",
+  "amount": "12.3456789",
+  "timestamp": "2026-05-29T12:00:00.000Z",
+  "expiresAt": "2026-05-29T12:15:00.000Z",
+  "memo": "Coffee",
+  "requestId": "req_123",
+  "metadata": {
+    "table": 7
+  }
+}
+```
+
+## Common Invalid Payloads
+
+Unsupported asset:
+
+```json
+{
+  "type": "payment-request",
+  "version": 1,
+  "recipient": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "asset": "BTC",
+  "amount": "12.50",
+  "timestamp": "2026-05-29T12:00:00.000Z",
+  "expiresAt": "2026-05-29T12:15:00.000Z"
+}
+```
+
+Error:
+
+```json
+{
+  "code": "PAYMENT_REQUEST_ASSET_UNSUPPORTED",
+  "message": "asset must be one of: XLM, USDC.",
+  "field": "asset"
+}
+```
+
+Invalid amount:
+
+```json
+{
+  "type": "payment-request",
+  "version": 1,
+  "recipient": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "asset": "USDC",
+  "amount": "1.12345678",
+  "timestamp": "2026-05-29T12:00:00.000Z",
+  "expiresAt": "2026-05-29T12:15:00.000Z"
+}
+```
+
+Error:
+
+```json
+{
+  "code": "PAYMENT_REQUEST_AMOUNT_INVALID",
+  "message": "amount must be a positive decimal string with at most 7 decimal places.",
+  "field": "amount"
+}
+```
+
+Expiration before timestamp:
+
+```json
+{
+  "type": "payment-request",
+  "version": 1,
+  "recipient": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "asset": "XLM",
+  "amount": "12.50",
+  "timestamp": "2026-05-29T12:00:00.000Z",
+  "expiresAt": "2026-05-29T11:59:59.000Z"
+}
+```
+
+Errors:
+
+```json
+[
+  {
+    "code": "PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW",
+    "message": "expiresAt must be in the future.",
+    "field": "expiresAt"
+  },
+  {
+    "code": "PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW",
+    "message": "expiresAt must be after timestamp.",
+    "field": "expiresAt"
+  }
+]
+```
+
+Invalid Stellar recipient:
+
+```json
+{
+  "type": "payment-request",
+  "version": 1,
+  "recipient": "not-stellar",
+  "asset": "XLM",
+  "amount": "12.50",
+  "timestamp": "2026-05-29T12:00:00.000Z",
+  "expiresAt": "2026-05-29T12:15:00.000Z"
+}
+```
+
+Error:
+
+```json
+{
+  "code": "PAYMENT_REQUEST_RECIPIENT_INVALID",
+  "message": "recipient must be a Stellar public key starting with G.",
+  "field": "recipient"
+}
+```
+
+## Versioning Strategy
+
+`type` identifies the protocol family and `version` identifies the exact
+contract. Consumers should dispatch validation by `(type, version)`.
+
+Backward-compatible v1 changes may clarify documentation, add optional fields
+that old consumers can ignore only after the unknown-field rule is intentionally
+revised, or add examples without changing validation behavior.
+
+Breaking changes require a new version, such as `version: 2`. A future
+`payment-request.v2` validator should live beside v1, keep v1 tests intact, and
+allow clients and servers to negotiate or route by version during migration.

--- a/src/payments/contracts/payment-request.v1.spec.ts
+++ b/src/payments/contracts/payment-request.v1.spec.ts
@@ -1,0 +1,250 @@
+import {
+  PaymentRequestV1,
+  validatePaymentRequestV1,
+} from './payment-request.v1';
+
+const NOW = new Date('2026-05-29T12:00:00.000Z');
+const VALID_RECIPIENT = `G${'A'.repeat(55)}`;
+
+function validPayload(
+  overrides: Partial<PaymentRequestV1> = {},
+): PaymentRequestV1 {
+  return {
+    type: 'payment-request',
+    version: 1,
+    recipient: VALID_RECIPIENT,
+    asset: 'XLM',
+    amount: '12.3456789',
+    timestamp: '2026-05-29T12:00:00.000Z',
+    expiresAt: '2026-05-29T12:15:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('payment-request.v1 contract', () => {
+  it('accepts a valid minimal payment request', () => {
+    const result = validatePaymentRequestV1(validPayload(), NOW);
+
+    expect(result).toEqual({
+      valid: true,
+      value: validPayload(),
+      errors: [],
+    });
+  });
+
+  it('accepts optional memo, requestId, and metadata fields', () => {
+    const payload = validPayload({
+      memo: 'Coffee',
+      requestId: 'req_123',
+      metadata: { table: 7 },
+    });
+
+    const result = validatePaymentRequestV1(payload, NOW);
+
+    expect(result).toEqual({
+      valid: true,
+      value: payload,
+      errors: [],
+    });
+  });
+
+  it('rejects missing required fields deterministically', () => {
+    const payload: Partial<PaymentRequestV1> = validPayload();
+    delete payload.recipient;
+
+    expect(validatePaymentRequestV1(payload, NOW)).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_FIELD_REQUIRED',
+          message: 'Missing required field: recipient.',
+          field: 'recipient',
+        },
+      ],
+    });
+  });
+
+  it('rejects unsupported contract type', () => {
+    expect(
+      validatePaymentRequestV1(validPayload({ type: 'invoice' as never }), NOW),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_TYPE_UNSUPPORTED',
+          message: 'type must be payment-request.',
+          field: 'type',
+        },
+      ],
+    });
+  });
+
+  it('rejects unsupported contract version', () => {
+    expect(
+      validatePaymentRequestV1(validPayload({ version: 2 as 1 }), NOW),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_VERSION_UNSUPPORTED',
+          message: 'version must be 1.',
+          field: 'version',
+        },
+      ],
+    });
+  });
+
+  it('rejects unsupported assets', () => {
+    expect(
+      validatePaymentRequestV1(validPayload({ asset: 'BTC' as never }), NOW),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_ASSET_UNSUPPORTED',
+          message: 'asset must be one of: XLM, USDC.',
+          field: 'asset',
+        },
+      ],
+    });
+  });
+
+  it.each(['0', '-1', '1.12345678', '1.', '01'])(
+    'rejects invalid amount %s',
+    (amount) => {
+      expect(validatePaymentRequestV1(validPayload({ amount }), NOW)).toEqual({
+        valid: false,
+        errors: [
+          {
+            code: 'PAYMENT_REQUEST_AMOUNT_INVALID',
+            message:
+              'amount must be a positive decimal string with at most 7 decimal places.',
+            field: 'amount',
+          },
+        ],
+      });
+    },
+  );
+
+  it('rejects invalid Stellar recipients', () => {
+    expect(
+      validatePaymentRequestV1(validPayload({ recipient: 'not-stellar' }), NOW),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_RECIPIENT_INVALID',
+          message: 'recipient must be a Stellar public key starting with G.',
+          field: 'recipient',
+        },
+      ],
+    });
+  });
+
+  it('rejects timestamps outside the allowed server clock window', () => {
+    expect(
+      validatePaymentRequestV1(
+        validPayload({ timestamp: '2026-05-29T11:54:59.000Z' }),
+        NOW,
+      ),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_TIMESTAMP_OUT_OF_WINDOW',
+          message: 'timestamp must be within 5 minutes of server time.',
+          field: 'timestamp',
+        },
+      ],
+    });
+  });
+
+  it('rejects invalid timestamp formats', () => {
+    expect(
+      validatePaymentRequestV1(
+        validPayload({ timestamp: '2026-05-29 12:00:00' }),
+        NOW,
+      ),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_TIMESTAMP_INVALID',
+          message: 'timestamp must be an ISO 8601 UTC date-time string.',
+          field: 'timestamp',
+        },
+      ],
+    });
+  });
+
+  it('rejects expirations before the timestamp', () => {
+    expect(
+      validatePaymentRequestV1(
+        validPayload({ expiresAt: '2026-05-29T11:59:59.000Z' }),
+        NOW,
+      ),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW',
+          message: 'expiresAt must be in the future.',
+          field: 'expiresAt',
+        },
+        {
+          code: 'PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW',
+          message: 'expiresAt must be after timestamp.',
+          field: 'expiresAt',
+        },
+      ],
+    });
+  });
+
+  it('rejects expirations more than 24 hours after the timestamp', () => {
+    expect(
+      validatePaymentRequestV1(
+        validPayload({ expiresAt: '2026-05-30T12:00:01.000Z' }),
+        NOW,
+      ),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW',
+          message: 'expiresAt must be no more than 24 hours after timestamp.',
+          field: 'expiresAt',
+        },
+      ],
+    });
+  });
+
+  it('rejects non-object metadata', () => {
+    expect(
+      validatePaymentRequestV1(validPayload({ metadata: [] as never }), NOW),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_METADATA_INVALID',
+          message: 'metadata must be a JSON object when provided.',
+          field: 'metadata',
+        },
+      ],
+    });
+  });
+
+  it('rejects unknown fields', () => {
+    expect(
+      validatePaymentRequestV1({ ...validPayload(), extra: true }, NOW),
+    ).toEqual({
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_FIELD_UNKNOWN',
+          message: 'Unknown field: extra.',
+          field: 'payload',
+        },
+      ],
+    });
+  });
+});

--- a/src/payments/contracts/payment-request.v1.ts
+++ b/src/payments/contracts/payment-request.v1.ts
@@ -1,0 +1,432 @@
+export const PAYMENT_REQUEST_V1_TYPE = 'payment-request';
+export const PAYMENT_REQUEST_V1_VERSION = 1;
+
+export const PAYMENT_REQUEST_V1_SUPPORTED_ASSETS = ['XLM', 'USDC'] as const;
+
+export type PaymentRequestV1Asset =
+  (typeof PAYMENT_REQUEST_V1_SUPPORTED_ASSETS)[number];
+
+export interface PaymentRequestV1 {
+  type: typeof PAYMENT_REQUEST_V1_TYPE;
+  version: typeof PAYMENT_REQUEST_V1_VERSION;
+  recipient: string;
+  asset: PaymentRequestV1Asset;
+  amount: string;
+  timestamp: string;
+  expiresAt: string;
+  memo?: string;
+  requestId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PaymentRequestValidationError {
+  code: PaymentRequestValidationErrorCode;
+  message: string;
+  field?: keyof PaymentRequestV1 | 'payload';
+}
+
+export type PaymentRequestValidationErrorCode =
+  | 'PAYMENT_REQUEST_PAYLOAD_INVALID'
+  | 'PAYMENT_REQUEST_FIELD_REQUIRED'
+  | 'PAYMENT_REQUEST_FIELD_UNKNOWN'
+  | 'PAYMENT_REQUEST_TYPE_UNSUPPORTED'
+  | 'PAYMENT_REQUEST_VERSION_UNSUPPORTED'
+  | 'PAYMENT_REQUEST_RECIPIENT_INVALID'
+  | 'PAYMENT_REQUEST_ASSET_UNSUPPORTED'
+  | 'PAYMENT_REQUEST_AMOUNT_INVALID'
+  | 'PAYMENT_REQUEST_TIMESTAMP_INVALID'
+  | 'PAYMENT_REQUEST_TIMESTAMP_OUT_OF_WINDOW'
+  | 'PAYMENT_REQUEST_EXPIRES_AT_INVALID'
+  | 'PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW'
+  | 'PAYMENT_REQUEST_METADATA_INVALID';
+
+export type PaymentRequestValidationResult =
+  | {
+      valid: true;
+      value: PaymentRequestV1;
+      errors: [];
+    }
+  | {
+      valid: false;
+      errors: PaymentRequestValidationError[];
+    };
+
+export const paymentRequestV1JsonSchema = {
+  $id: 'https://ding-payments.dev/contracts/payment-request.v1.schema.json',
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  title: 'payment-request.v1',
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'type',
+    'version',
+    'recipient',
+    'asset',
+    'amount',
+    'timestamp',
+    'expiresAt',
+  ],
+  properties: {
+    type: { const: PAYMENT_REQUEST_V1_TYPE },
+    version: { const: PAYMENT_REQUEST_V1_VERSION },
+    recipient: {
+      type: 'string',
+      pattern: '^G[A-Z2-7]{55}$',
+    },
+    asset: {
+      type: 'string',
+      enum: PAYMENT_REQUEST_V1_SUPPORTED_ASSETS,
+    },
+    amount: {
+      type: 'string',
+      pattern: '^(?!0+(?:\\.0{1,7})?$)(?:0|[1-9]\\d*)(?:\\.\\d{1,7})?$',
+    },
+    timestamp: {
+      type: 'string',
+      format: 'date-time',
+    },
+    expiresAt: {
+      type: 'string',
+      format: 'date-time',
+    },
+    memo: {
+      type: 'string',
+      maxLength: 280,
+    },
+    requestId: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 128,
+    },
+    metadata: {
+      type: 'object',
+      additionalProperties: true,
+    },
+  },
+} as const;
+
+const ALLOWED_FIELDS = new Set([
+  'type',
+  'version',
+  'recipient',
+  'asset',
+  'amount',
+  'timestamp',
+  'expiresAt',
+  'memo',
+  'requestId',
+  'metadata',
+]);
+
+const REQUIRED_FIELDS: Array<keyof PaymentRequestV1> = [
+  'type',
+  'version',
+  'recipient',
+  'asset',
+  'amount',
+  'timestamp',
+  'expiresAt',
+];
+
+const STELLAR_ADDRESS_PATTERN = /^G[A-Z2-7]{55}$/;
+const ISO_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const AMOUNT_PATTERN = /^(?:0|[1-9]\d*)(?:\.\d{1,7})?$/;
+const MAX_DECIMAL_PLACES = 7;
+const TIMESTAMP_CLOCK_SKEW_MS = 5 * 60 * 1000;
+const MAX_EXPIRATION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export function validatePaymentRequestV1(
+  payload: unknown,
+  now = new Date(),
+): PaymentRequestValidationResult {
+  const errors: PaymentRequestValidationError[] = [];
+
+  if (!isPlainObject(payload)) {
+    return {
+      valid: false,
+      errors: [
+        {
+          code: 'PAYMENT_REQUEST_PAYLOAD_INVALID',
+          message: 'Payment request payload must be a JSON object.',
+          field: 'payload',
+        },
+      ],
+    };
+  }
+
+  for (const field of Object.keys(payload).sort()) {
+    if (!ALLOWED_FIELDS.has(field)) {
+      errors.push({
+        code: 'PAYMENT_REQUEST_FIELD_UNKNOWN',
+        message: `Unknown field: ${field}.`,
+        field: 'payload',
+      });
+    }
+  }
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!(field in payload)) {
+      errors.push({
+        code: 'PAYMENT_REQUEST_FIELD_REQUIRED',
+        message: `Missing required field: ${field}.`,
+        field,
+      });
+    }
+  }
+
+  validateType(payload.type, errors);
+  validateVersion(payload.version, errors);
+  validateRecipient(payload.recipient, errors);
+  validateAsset(payload.asset, errors);
+  validateAmount(payload.amount, errors);
+  validateMetadata(payload.metadata, errors);
+
+  const timestamp = parseIsoUtcDate(payload.timestamp);
+  const expiresAt = parseIsoUtcDate(payload.expiresAt);
+
+  validateTimestamp(payload.timestamp, timestamp, now, errors);
+  validateExpiresAt(payload.expiresAt, expiresAt, timestamp, now, errors);
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: payload as unknown as PaymentRequestV1,
+    errors: [],
+  };
+}
+
+function validateType(
+  type: unknown,
+  errors: PaymentRequestValidationError[],
+): void {
+  if (type === undefined) {
+    return;
+  }
+
+  if (type !== PAYMENT_REQUEST_V1_TYPE) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_TYPE_UNSUPPORTED',
+      message: 'type must be payment-request.',
+      field: 'type',
+    });
+  }
+}
+
+function validateVersion(
+  version: unknown,
+  errors: PaymentRequestValidationError[],
+): void {
+  if (version === undefined) {
+    return;
+  }
+
+  if (version !== PAYMENT_REQUEST_V1_VERSION) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_VERSION_UNSUPPORTED',
+      message: 'version must be 1.',
+      field: 'version',
+    });
+  }
+}
+
+function validateRecipient(
+  recipient: unknown,
+  errors: PaymentRequestValidationError[],
+): void {
+  if (recipient === undefined) {
+    return;
+  }
+
+  if (
+    typeof recipient !== 'string' ||
+    !STELLAR_ADDRESS_PATTERN.test(recipient)
+  ) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_RECIPIENT_INVALID',
+      message: 'recipient must be a Stellar public key starting with G.',
+      field: 'recipient',
+    });
+  }
+}
+
+function validateAsset(
+  asset: unknown,
+  errors: PaymentRequestValidationError[],
+): void {
+  if (asset === undefined) {
+    return;
+  }
+
+  if (
+    typeof asset !== 'string' ||
+    !PAYMENT_REQUEST_V1_SUPPORTED_ASSETS.includes(
+      asset as PaymentRequestV1Asset,
+    )
+  ) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_ASSET_UNSUPPORTED',
+      message: 'asset must be one of: XLM, USDC.',
+      field: 'asset',
+    });
+  }
+}
+
+function validateAmount(
+  amount: unknown,
+  errors: PaymentRequestValidationError[],
+): void {
+  if (amount === undefined) {
+    return;
+  }
+
+  if (typeof amount !== 'string' || !AMOUNT_PATTERN.test(amount)) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_AMOUNT_INVALID',
+      message:
+        'amount must be a positive decimal string with at most 7 decimal places.',
+      field: 'amount',
+    });
+    return;
+  }
+
+  const [, fractional = ''] = amount.split('.');
+  const numericAmount = Number(amount);
+
+  if (
+    !Number.isFinite(numericAmount) ||
+    numericAmount <= 0 ||
+    fractional.length > MAX_DECIMAL_PLACES
+  ) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_AMOUNT_INVALID',
+      message:
+        'amount must be a positive decimal string with at most 7 decimal places.',
+      field: 'amount',
+    });
+  }
+}
+
+function validateTimestamp(
+  timestampValue: unknown,
+  timestamp: Date | undefined,
+  now: Date,
+  errors: PaymentRequestValidationError[],
+): void {
+  if (timestampValue === undefined) {
+    return;
+  }
+
+  if (!timestamp) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_TIMESTAMP_INVALID',
+      message: 'timestamp must be an ISO 8601 UTC date-time string.',
+      field: 'timestamp',
+    });
+    return;
+  }
+
+  const earliestTimestamp = now.getTime() - TIMESTAMP_CLOCK_SKEW_MS;
+  const latestTimestamp = now.getTime() + TIMESTAMP_CLOCK_SKEW_MS;
+
+  if (
+    timestamp.getTime() < earliestTimestamp ||
+    timestamp.getTime() > latestTimestamp
+  ) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_TIMESTAMP_OUT_OF_WINDOW',
+      message: 'timestamp must be within 5 minutes of server time.',
+      field: 'timestamp',
+    });
+  }
+}
+
+function validateExpiresAt(
+  expiresAtValue: unknown,
+  expiresAt: Date | undefined,
+  timestamp: Date | undefined,
+  now: Date,
+  errors: PaymentRequestValidationError[],
+): void {
+  if (expiresAtValue === undefined) {
+    return;
+  }
+
+  if (!expiresAt) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_EXPIRES_AT_INVALID',
+      message: 'expiresAt must be an ISO 8601 UTC date-time string.',
+      field: 'expiresAt',
+    });
+    return;
+  }
+
+  if (expiresAt.getTime() <= now.getTime()) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW',
+      message: 'expiresAt must be in the future.',
+      field: 'expiresAt',
+    });
+  }
+
+  if (timestamp && expiresAt.getTime() <= timestamp.getTime()) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW',
+      message: 'expiresAt must be after timestamp.',
+      field: 'expiresAt',
+    });
+  }
+
+  if (
+    timestamp &&
+    expiresAt.getTime() - timestamp.getTime() > MAX_EXPIRATION_WINDOW_MS
+  ) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_EXPIRES_AT_OUT_OF_WINDOW',
+      message: 'expiresAt must be no more than 24 hours after timestamp.',
+      field: 'expiresAt',
+    });
+  }
+}
+
+function validateMetadata(
+  metadata: unknown,
+  errors: PaymentRequestValidationError[],
+): void {
+  if (metadata === undefined) {
+    return;
+  }
+
+  if (!isPlainObject(metadata)) {
+    errors.push({
+      code: 'PAYMENT_REQUEST_METADATA_INVALID',
+      message: 'metadata must be a JSON object when provided.',
+      field: 'metadata',
+    });
+  }
+}
+
+function parseIsoUtcDate(value: unknown): Date | undefined {
+  if (typeof value !== 'string' || !ISO_UTC_PATTERN.test(value)) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return date;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}


### PR DESCRIPTION
## Summary #5 

- Added the canonical `payment-request.v1` NFC payment request contract for Ding payment flows.
- Defined TypeScript DTO types, a JSON Schema constant, supported MVP assets, and deterministic validation errors.
- Documented required/optional fields, validation rules, valid and invalid payload examples, and the forward versioning strategy for future `v2` contracts.

## Validation Covered

- Required fields: `type`, `version`, `recipient`, `asset`, `amount`, `timestamp`, `expiresAt`
- Optional fields: `memo`, `requestId`, `metadata`
- Positive decimal amount strings with max 7 decimal places
- MVP asset allowlist: `XLM`, `USDC`
- Stellar `G...` public-key format validation
- Timestamp clock-skew validation
- Expiration ordering and maximum lifetime validation
- Unknown-field rejection with stable error codes/messages

## Tests

- Added 18 focused contract tests covering valid payloads and common invalid payload cases.
- Verified with `npx jest --runInBand payment-request.v1.spec.ts`.

## Notes

Full repo build/test checks are currently blocked by existing unrelated Prisma/Supabase setup issues, including Prisma 7 schema/client generation incompatibilities and existing service type errors. This change only adds the new contract, tests, and documentation files.

Closes #5 